### PR TITLE
RowContextActions: Add toArray function to allow rowContextActions json encodeable

### DIFF
--- a/src/BaseFeatures/ContextActions/BaseAction.php
+++ b/src/BaseFeatures/ContextActions/BaseAction.php
@@ -3,7 +3,6 @@
 namespace BluefynInternational\ReportEngine\BaseFeatures\ContextActions;
 
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Collection;
 
 class BaseAction implements Arrayable
 {

--- a/src/BaseFeatures/ContextActions/BaseAction.php
+++ b/src/BaseFeatures/ContextActions/BaseAction.php
@@ -2,7 +2,10 @@
 
 namespace BluefynInternational\ReportEngine\BaseFeatures\ContextActions;
 
-class BaseAction
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+
+class BaseAction implements Arrayable
 {
     public const POST = 'post';
     public const GET = 'get';

--- a/src/BaseFeatures/ContextActions/BaseAction.php
+++ b/src/BaseFeatures/ContextActions/BaseAction.php
@@ -155,7 +155,7 @@ class BaseAction
     public function toArray(): array
     {
         return [
-            'http_action'   => $this->getHttpAction(),
+            'http_action' => $this->getHttpAction(),
             'label' => $this->getLabel(),
             'link_template' => $this->getLinkTemplate(),
             'link_template_replacements' => $this->getLinkTemplateReplacements(),

--- a/src/BaseFeatures/ContextActions/BaseAction.php
+++ b/src/BaseFeatures/ContextActions/BaseAction.php
@@ -151,4 +151,15 @@ class BaseAction
     {
         return $this->label;
     }
+
+    public function toArray(): array
+    {
+        return [
+            'http_action'   => $this->getHttpAction(),
+            'label' => $this->getLabel(),
+            'link_template' => $this->getLinkTemplate(),
+            'link_template_replacements' => $this->getLinkTemplateReplacements(),
+            'message' => $this->getMessage(),
+        ];
+    }
 }

--- a/src/ReportBase.php
+++ b/src/ReportBase.php
@@ -421,7 +421,7 @@ abstract class ReportBase implements Responsable, Arrayable
         $return = [];
 
         foreach ($this->rowContextActions() as $action) {
-            $return []= $action->toArray();
+            $return [] = $action->toArray();
         }
 
         return $return;

--- a/src/ReportBase.php
+++ b/src/ReportBase.php
@@ -418,13 +418,7 @@ abstract class ReportBase implements Responsable, Arrayable
 
     public function rowContextActionsForConfig() : array
     {
-        $return = [];
-
-        foreach ($this->rowContextActions() as $action) {
-            $return []= $action->toArray();
-        }
-
-        return $return;
+        return collect($this->rowContextActions())->toArray();
     }
 
     public function rowContextActions() : ?array

--- a/src/ReportBase.php
+++ b/src/ReportBase.php
@@ -337,7 +337,7 @@ abstract class ReportBase implements Responsable, Arrayable
             'filterColumns' => $this->getFilterableColumns(),
             'autoloadInitialData' => $this->autoloadInitialData,
             'route' => $this->getRoute(),
-            'rowContextActions' => $this->rowContextActions(),
+            'rowContextActions' => $this->rowContextActionsForConfig(),
             'reportButtons' => $this->reportButtons(),
             'selectable' => $this->selectable,
             'movableColumns' => $this->movableColumns,
@@ -414,6 +414,17 @@ abstract class ReportBase implements Responsable, Arrayable
     public function toHtml() : Response
     {
         return response()->view('report-engine::base-web', $this->getConfig());
+    }
+
+    public function rowContextActionsForConfig() : array
+    {
+        $return = [];
+
+        foreach ($this->rowContextActions() as $action) {
+            $return []= $action->toArray();
+        }
+
+        return $return;
     }
 
     public function rowContextActions() : ?array


### PR DESCRIPTION
Add a BaseAction->toArray() function
Add rowContextActionsForConfig function that uses the toArray function allowing the rowContextActions to be successfully encoded when hitting a reports `.config` endpoint