### PR TITLE
Allow overriding input and output formats of datetime columns

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [ 7.4, 8.0 ]
+        php: [ 8.0, 8.1 ]
     steps:
       - uses: actions/checkout@v2
 

--- a/src/BaseFeatures/Data/Types/DateTime.php
+++ b/src/BaseFeatures/Data/Types/DateTime.php
@@ -17,26 +17,76 @@ class DateTime extends BaseType
     /**
      * @var null|string like "America/New_York".
      */
-    protected $outputTzName = null;
+    protected string|null $outputTzName = null;
 
-    /**
-     * @var string
-     */
-    protected $date_time_format = 'L';
+    protected string|null $inputFormat = 'YYYY-MM-DD HH:ii:ss';
 
-    /**
-     * DateTime constructor.
-     *
-     * @param string|null $output_tz_name
-     * @param string|null $placeholder
-     * @param string|null $date_time_format
-     */
-    public function __construct(?string $date_time_format = null, ?string $placeholder = null, ?string $output_tz_name = null)
-    {
-        $this->outputTzName = $output_tz_name;
-        $this->date_time_format = $date_time_format ?? $this->date_time_format;
+    protected string $outputFormat = 'L';
+
+    public function __construct(
+        string|null $outputFormat = null,
+        string|null $placeholder = null,
+        string|null $outputTimezone = null
+    ) {
+        $this->setOutputFormat($outputFormat ?? $this->outputFormat)
+            ->setOutputTimezone($outputTimezone)
+            ->setPlaceholder($placeholder ?? $this->placeholder);
         $this->addClass('datepicker');
-        $this->placeholder = $placeholder ?? $this->placeholder;
+    }
+
+    public function setOutputFormat(string|null $format) : self
+    {
+        $this->outputFormat = $format;
+
+        return $this;
+    }
+
+    public function setPlaceholder(string $placeholder) : self
+    {
+        $this->placeholder = $placeholder;
+
+        return $this;
+    }
+
+    public function setInputFormat(string|null $format) : self
+    {
+        $this->inputFormat = $format;
+
+        return $this;
+    }
+
+    public function setOutputTimezone(string|null $timezone) : self
+    {
+        $this->outputTzName = $timezone;
+
+        return $this;
+    }
+
+    public function formatter(): string
+    {
+        return 'datetime';
+    }
+
+    public function formatterParams(): array
+    {
+        $params = [
+            'outputFormat' => $this->outputFormat,
+        ];
+
+        if ($this->inputFormat) {
+            $params['inputFormat'] = $this->inputFormat;
+        }
+
+        if ($this->outputTzName) {
+            $params['timezone'] = $this->outputTzName;
+        }
+
+        return $params;
+    }
+
+    public function inputType() : string
+    {
+        return 'date';
     }
 
     /**
@@ -47,7 +97,7 @@ class DateTime extends BaseType
      */
     public function typeFormat($value, ?object $result = null) : ?string
     {
-        return (new Carbon($value))->toDateTimeString(); //->setTimezone($this->outputTzName)->format($this->date_time_format);
+        return (new Carbon($value))->toDateTimeString(); //->setTimezone($this->outputTzName)->format($this->outputFormat);
     }
 
     /**
@@ -67,20 +117,6 @@ class DateTime extends BaseType
         ];
     }
 
-    public function formatter(): string
-    {
-        return 'datetime';
-    }
-
-    public function formatterParams(): array
-    {
-        return [
-            'inputFormat' => 'YYYY-MM-DD HH:ii:ss',
-            'outputFormat' => $this->date_time_format,
-            'timezone' => $this->outputTzName ?? 'America/New_York',
-        ];
-    }
-
     /**
      * @param string     $label
      * @param string     $name
@@ -93,7 +129,7 @@ class DateTime extends BaseType
     public function renderFilter(string $label, string $name, array $action_types, BaseType $columnType, Collection $value)
     {
         $value = $value->map(function ($value) {
-            return Carbon::parse($value)->isoFormat($this->date_time_format);
+            return Carbon::parse($value)->isoFormat($this->outputFormat);
         });
 
         return view('report-engine::partials.date-filter')->with([
@@ -106,10 +142,5 @@ class DateTime extends BaseType
             'placeholder' => $this->placeholder(),
             'selected_operators' => $this->getSelectedOperators($value),
         ]);
-    }
-
-    public function inputType() : string
-    {
-        return 'date';
     }
 }


### PR DESCRIPTION
This allows for better support of Tabulator 5.x which changed date formatters from Moment to Luxon