### PR TITLE
Add initial metadata support, Improve support for client timezones

### DIFF
--- a/resources/views/base-web.blade.php
+++ b/resources/views/base-web.blade.php
@@ -105,6 +105,19 @@
             })
         }
 
+        function addMetaDataToUrl(url)
+        {
+            let metaData = {
+                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            }
+
+            let encodedMetaData = btoa(JSON.stringify(metaData))
+
+            url.searchParams.append('metaData', encodedMetaData)
+
+            return url
+        }
+
         (() => {
             $('#filterContainer .custom-select').change()
 
@@ -177,8 +190,17 @@
                     }
                 })
 
-                history.replaceState(null, '', endpoint.replace('.json', '') + '?' + filterParams.toString());
-                table.setData(endpoint + '?' + filterParams.toString());
+                let viewReportUrl = endpoint.replace('.json', '') + '?' + filterParams.toString()
+                let dataReportUrl = endpoint + '?' + filterParams.toString()
+
+                viewReportUrlObject = new URL(viewReportUrl)
+                dataReportUrlObject = new URL(dataReportUrl)
+
+                viewReportUrlObject = addMetaDataToUrl(viewReportUrlObject)
+                dataReportUrlObject = addMetaDataToUrl(dataReportUrlObject)
+
+                history.replaceState(null, '', viewReportUrlObject.toString());
+                table.setData(dataReportUrlObject.toString());
             });
 
             @if($autoloadInitialData) {

--- a/src/BaseFeatures/Data/Types/DateTime.php
+++ b/src/BaseFeatures/Data/Types/DateTime.php
@@ -57,7 +57,7 @@ class DateTime extends BaseType
         return $this;
     }
 
-    public function getOutputTimezone() : string
+    public function getOutputTimezone() : ?string
     {
         return $this->outputTzName;
     }

--- a/src/BaseFeatures/Data/Types/DateTime.php
+++ b/src/BaseFeatures/Data/Types/DateTime.php
@@ -23,6 +23,8 @@ class DateTime extends BaseType
 
     protected string $outputFormat = 'L';
 
+    protected ?string $formatter = 'datetime';
+
     public function __construct(
         string|null $outputFormat = null,
         string|null $placeholder = null,
@@ -64,7 +66,7 @@ class DateTime extends BaseType
 
     public function formatter(): string
     {
-        return 'datetime';
+        return $this->formatter;
     }
 
     public function formatterParams(): array

--- a/src/BaseFeatures/Data/Types/DateTime.php
+++ b/src/BaseFeatures/Data/Types/DateTime.php
@@ -57,6 +57,11 @@ class DateTime extends BaseType
         return $this;
     }
 
+    public function getOutputTimezone() : string
+    {
+        return $this->outputTzName;
+    }
+
     public function setOutputTimezone(string|null $timezone) : self
     {
         $this->outputTzName = $timezone;

--- a/src/BaseFeatures/Filters/BaseFilter.php
+++ b/src/BaseFeatures/Filters/BaseFilter.php
@@ -24,10 +24,10 @@ abstract class BaseFilter implements Arrayable
     /**
      * BaseFilter constructor.
      *
-     * @param Column $column
-     * @param null   $value
+     * @param Column       $column
+     * @param mixed|null   $value
      */
-    public function __construct(Column $column, $value = null)
+    public function __construct(Column $column, mixed $value = null)
     {
         $this->setColumn($column);
         $this->setValue($value);

--- a/src/BaseFeatures/Filters/DoesNotEqualFilter.php
+++ b/src/BaseFeatures/Filters/DoesNotEqualFilter.php
@@ -2,7 +2,9 @@
 
 namespace BluefynInternational\ReportEngine\BaseFeatures\Filters;
 
+use Carbon\Carbon;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Arr;
 
 class DoesNotEqualFilter extends BaseFilter
 {
@@ -44,5 +46,28 @@ class DoesNotEqualFilter extends BaseFilter
     public static function key(): string
     {
         return 'does_not_equal';
+    }
+
+    /**
+     * @return null|string|Carbon
+     */
+    public function getValue(array $options = [])
+    {
+        if ($this->valueIsDate()) {
+            /**
+             * @var Carbon $value
+             */
+            $value = parent::getValue();
+            $timeZoneString = $this->getColumn()->type()->getOutputTimezone()
+                ?? Arr::get($options, 'timezone');
+
+            if ($timeZoneString) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            return $value->utc();
+        }
+
+        return parent::getValue();
     }
 }

--- a/src/BaseFeatures/Filters/EqualsFilter.php
+++ b/src/BaseFeatures/Filters/EqualsFilter.php
@@ -3,8 +3,6 @@
 namespace BluefynInternational\ReportEngine\BaseFeatures\Filters;
 
 use Illuminate\Database\Query\Builder;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Carbon;
 
 class EqualsFilter extends BaseFilter
 {
@@ -17,17 +15,11 @@ class EqualsFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         if ($this->valueIsDate()) {
-            $value = Carbon::parse($this->getValue());
+            $greaterThanEqual = new GreaterThanOrEqualFilter($this->getColumn(), $this->getValue());
+            $lessThanEqual = new LessThanOrEqualFilter($this->getColumn(), $this->getValue());
+            $builder = $greaterThanEqual->apply($builder, $options);
 
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
-                $value->shiftTimezone($timeZoneString);
-            }
-
-            $greaterThanEqual = new GreaterThanOrEqualFilter($this->getColumn(), $value);
-            $lessThanEqual = new LessThanOrEqualFilter($this->getColumn(), $value);
-            $builder = $greaterThanEqual->apply($builder);
-
-            return $lessThanEqual->apply($builder);
+            return $lessThanEqual->apply($builder, $options);
         }
 
         $action = $this->getAction();

--- a/src/BaseFeatures/Filters/EqualsFilter.php
+++ b/src/BaseFeatures/Filters/EqualsFilter.php
@@ -14,26 +14,26 @@ class EqualsFilter extends BaseFilter
      *
      * @return Builder
      */
-   public function apply(Builder $builder, array $options = []) : Builder
-   {
-       if ($this->valueIsDate()) {
-           $value = Carbon::parse($this->getValue());
+    public function apply(Builder $builder, array $options = []) : Builder
+    {
+        if ($this->valueIsDate()) {
+            $value = Carbon::parse($this->getValue());
 
-           if ($timeZoneString = Arr::get($options, 'timezone')) {
-               $value->shiftTimezone($timeZoneString);
-           }
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
 
-           $greaterThanEqual = new GreaterThanOrEqualFilter($this->getColumn(), $value);
-           $lessThanEqual = new LessThanOrEqualFilter($this->getColumn(), $value);
-           $builder = $greaterThanEqual->apply($builder);
+            $greaterThanEqual = new GreaterThanOrEqualFilter($this->getColumn(), $value);
+            $lessThanEqual = new LessThanOrEqualFilter($this->getColumn(), $value);
+            $builder = $greaterThanEqual->apply($builder);
 
-           return $lessThanEqual->apply($builder);
-       }
+            return $lessThanEqual->apply($builder);
+        }
 
-       $action = $this->getAction();
+        $action = $this->getAction();
 
-       return $builder->$action($this->getField(), $this->getValue());
-   }
+        return $builder->$action($this->getField(), $this->getValue());
+    }
 
     /**
      * @return string

--- a/src/BaseFeatures/Filters/GreaterThanFilter.php
+++ b/src/BaseFeatures/Filters/GreaterThanFilter.php
@@ -2,7 +2,9 @@
 
 namespace BluefynInternational\ReportEngine\BaseFeatures\Filters;
 
+use Carbon\Carbon;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Arr;
 
 class GreaterThanFilter extends BaseFilter
 {
@@ -15,8 +17,21 @@ class GreaterThanFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         $action = $this->getAction();
+        $value = $this->getValue();
 
-        return $builder->$action($this->getField(), '>', $this->getValue());
+        if ($this->valueIsDate()) {
+
+            /**
+             * @var Carbon $value
+             */
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            $value = $value->utc()->toDateTimeString();
+        }
+
+        return $builder->$action($this->getField(), '>', $value);
     }
 
     /**
@@ -25,7 +40,7 @@ class GreaterThanFilter extends BaseFilter
     public function getValue()
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->endOfDay()->toDateTimeString();
+            return parent::getValue()->endOfDay();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Filters/GreaterThanFilter.php
+++ b/src/BaseFeatures/Filters/GreaterThanFilter.php
@@ -17,19 +17,7 @@ class GreaterThanFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         $action = $this->getAction();
-        $value = $this->getValue();
-
-        if ($this->valueIsDate()) {
-
-            /**
-             * @var Carbon $value
-             */
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
-                $value->shiftTimezone($timeZoneString);
-            }
-
-            $value = $value->utc()->toDateTimeString();
-        }
+        $value = $this->getValue($options);
 
         return $builder->$action($this->getField(), '>', $value);
     }
@@ -37,10 +25,18 @@ class GreaterThanFilter extends BaseFilter
     /**
      * @return null|string|mixed
      */
-    public function getValue()
+    public function getValue(array $options = [])
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->endOfDay();
+            /**
+             * @var Carbon $value
+             */
+            $value = parent::getValue();
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            return $value->endOfDay()->utc()->toDateTimeString();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Filters/GreaterThanFilter.php
+++ b/src/BaseFeatures/Filters/GreaterThanFilter.php
@@ -32,7 +32,10 @@ class GreaterThanFilter extends BaseFilter
              * @var Carbon $value
              */
             $value = parent::getValue();
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
+            $timeZoneString = $this->getColumn()->type()->getOutputTimezone()
+                ?? Arr::get($options, 'timezone');
+
+            if ($timeZoneString) {
                 $value->shiftTimezone($timeZoneString);
             }
 

--- a/src/BaseFeatures/Filters/GreaterThanOrEqualFilter.php
+++ b/src/BaseFeatures/Filters/GreaterThanOrEqualFilter.php
@@ -32,7 +32,10 @@ class GreaterThanOrEqualFilter extends BaseFilter
              * @var Carbon $value
              */
             $value = parent::getValue();
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
+            $timeZoneString = $this->getColumn()->type()->getOutputTimezone()
+                ?? Arr::get($options, 'timezone');
+
+            if ($timeZoneString) {
                 $value->shiftTimezone($timeZoneString);
             }
 

--- a/src/BaseFeatures/Filters/GreaterThanOrEqualFilter.php
+++ b/src/BaseFeatures/Filters/GreaterThanOrEqualFilter.php
@@ -17,18 +17,7 @@ class GreaterThanOrEqualFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         $action = $this->getAction();
-        $value = $this->getValue();
-
-        if ($this->valueIsDate()) {
-            /**
-             * @var Carbon $value
-             */
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
-                $value->shiftTimezone($timeZoneString);
-            }
-
-            $value = $value->utc()->toDateTimeString();
-        }
+        $value = $this->getValue($options);
 
         return $builder->$action($this->getField(), '>=', $value);
     }
@@ -36,10 +25,18 @@ class GreaterThanOrEqualFilter extends BaseFilter
     /**
      * @return null|string
      */
-    public function getValue()
+    public function getValue(array $options = [])
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->startOfDay();
+            /**
+             * @var Carbon $value
+             */
+            $value = parent::getValue();
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            return $value->startOfDay()->utc()->toDateTimeString();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Filters/GreaterThanOrEqualFilter.php
+++ b/src/BaseFeatures/Filters/GreaterThanOrEqualFilter.php
@@ -2,7 +2,9 @@
 
 namespace BluefynInternational\ReportEngine\BaseFeatures\Filters;
 
+use Carbon\Carbon;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Arr;
 
 class GreaterThanOrEqualFilter extends BaseFilter
 {
@@ -15,8 +17,20 @@ class GreaterThanOrEqualFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         $action = $this->getAction();
+        $value = $this->getValue();
 
-        return $builder->$action($this->getField(), '>=', $this->getValue());
+        if ($this->valueIsDate()) {
+            /**
+             * @var Carbon $value
+             */
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            $value = $value->utc()->toDateTimeString();
+        }
+
+        return $builder->$action($this->getField(), '>=', $value);
     }
 
     /**
@@ -25,7 +39,7 @@ class GreaterThanOrEqualFilter extends BaseFilter
     public function getValue()
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->startOfDay()->toDateTimeString();
+            return parent::getValue()->startOfDay();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Filters/LessThanFilter.php
+++ b/src/BaseFeatures/Filters/LessThanFilter.php
@@ -32,7 +32,10 @@ class LessThanFilter extends BaseFilter
              * @var Carbon $value
              */
             $value = parent::getValue();
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
+            $timeZoneString = $this->getColumn()->type()->getOutputTimezone()
+                ?? Arr::get($options, 'timezone');
+
+            if ($timeZoneString) {
                 $value->shiftTimezone($timeZoneString);
             }
 

--- a/src/BaseFeatures/Filters/LessThanFilter.php
+++ b/src/BaseFeatures/Filters/LessThanFilter.php
@@ -2,7 +2,9 @@
 
 namespace BluefynInternational\ReportEngine\BaseFeatures\Filters;
 
+use Carbon\Carbon;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Arr;
 
 class LessThanFilter extends BaseFilter
 {
@@ -15,8 +17,20 @@ class LessThanFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         $action = $this->getAction();
+        $value = $this->getValue();
 
-        return $builder->$action($this->getField(), '<', $this->getValue());
+        if ($this->valueIsDate()) {
+            /**
+             * @var Carbon $value
+             */
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            $value = $value->utc()->toDateTimeString();
+        }
+
+        return $builder->$action($this->getField(), '<', $value);
     }
 
     /**
@@ -25,7 +39,7 @@ class LessThanFilter extends BaseFilter
     public function getValue()
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->startOfDay()->toDateTimeString();
+            return parent::getValue()->startOfDay();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Filters/LessThanFilter.php
+++ b/src/BaseFeatures/Filters/LessThanFilter.php
@@ -17,18 +17,7 @@ class LessThanFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         $action = $this->getAction();
-        $value = $this->getValue();
-
-        if ($this->valueIsDate()) {
-            /**
-             * @var Carbon $value
-             */
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
-                $value->shiftTimezone($timeZoneString);
-            }
-
-            $value = $value->utc()->toDateTimeString();
-        }
+        $value = $this->getValue($options);
 
         return $builder->$action($this->getField(), '<', $value);
     }
@@ -36,10 +25,18 @@ class LessThanFilter extends BaseFilter
     /**
      * @return null|string
      */
-    public function getValue()
+    public function getValue(array $options = [])
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->startOfDay();
+            /**
+             * @var Carbon $value
+             */
+            $value = parent::getValue();
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            return $value->startOfDay()->utc()->toDateTimeString();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Filters/LessThanOrEqualFilter.php
+++ b/src/BaseFeatures/Filters/LessThanOrEqualFilter.php
@@ -25,7 +25,7 @@ class LessThanOrEqualFilter extends BaseFilter
     public function getValue()
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->endOfDay()->toDateTimeString();
+            return parent::getValue()->addDay()->toDateTimeString();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Filters/LessThanOrEqualFilter.php
+++ b/src/BaseFeatures/Filters/LessThanOrEqualFilter.php
@@ -2,7 +2,9 @@
 
 namespace BluefynInternational\ReportEngine\BaseFeatures\Filters;
 
+use Carbon\Carbon;
 use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Arr;
 
 class LessThanOrEqualFilter extends BaseFilter
 {
@@ -15,8 +17,20 @@ class LessThanOrEqualFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         $action = $this->getAction();
+        $value = $this->getValue();
 
-        return $builder->$action($this->getField(), '<=', $this->getValue());
+        if ($this->valueIsDate()) {
+            /**
+             * @var Carbon $value
+             */
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            $value = $value->utc()->toDateTimeString();
+        }
+
+        return $builder->$action($this->getField(), '<=', $value);
     }
 
     /**
@@ -25,7 +39,7 @@ class LessThanOrEqualFilter extends BaseFilter
     public function getValue()
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->addDay()->toDateTimeString();
+            return parent::getValue()->endOfDay();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Filters/LessThanOrEqualFilter.php
+++ b/src/BaseFeatures/Filters/LessThanOrEqualFilter.php
@@ -32,7 +32,10 @@ class LessThanOrEqualFilter extends BaseFilter
              * @var Carbon $value
              */
             $value = parent::getValue();
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
+            $timeZoneString = $this->getColumn()->type()->getOutputTimezone()
+                ?? Arr::get($options, 'timezone');
+
+            if ($timeZoneString) {
                 $value->shiftTimezone($timeZoneString);
             }
 

--- a/src/BaseFeatures/Filters/LessThanOrEqualFilter.php
+++ b/src/BaseFeatures/Filters/LessThanOrEqualFilter.php
@@ -17,18 +17,7 @@ class LessThanOrEqualFilter extends BaseFilter
     public function apply(Builder $builder, array $options = []) : Builder
     {
         $action = $this->getAction();
-        $value = $this->getValue();
-
-        if ($this->valueIsDate()) {
-            /**
-             * @var Carbon $value
-             */
-            if ($timeZoneString = Arr::get($options, 'timezone')) {
-                $value->shiftTimezone($timeZoneString);
-            }
-
-            $value = $value->utc()->toDateTimeString();
-        }
+        $value = $this->getValue($options);
 
         return $builder->$action($this->getField(), '<=', $value);
     }
@@ -36,10 +25,18 @@ class LessThanOrEqualFilter extends BaseFilter
     /**
      * @return null|string
      */
-    public function getValue()
+    public function getValue(array $options = [])
     {
         if ($this->valueIsDate()) {
-            return parent::getValue()->endOfDay();
+            /**
+             * @var Carbon $value
+             */
+            $value = parent::getValue();
+            if ($timeZoneString = Arr::get($options, 'timezone')) {
+                $value->shiftTimezone($timeZoneString);
+            }
+
+            return $value->endOfDay()->utc()->toDateTimeString();
         }
 
         return parent::getValue();

--- a/src/BaseFeatures/Traits/Filterable.php
+++ b/src/BaseFeatures/Traits/Filterable.php
@@ -21,10 +21,12 @@ trait Filterable
      */
     protected function applyFilters(array $params, Builder $builder) : Builder
     {
+        $options = $this->getMetaData();
+
         $this->getAppliedfilters($params)
-            ->each(function ($fields) use (&$builder) {
-                $fields->each(function ($filter) use (&$builder) {
-                    $builder = $this->filter($filter, $builder);
+            ->each(function ($fields) use ($options, &$builder) {
+                $fields->each(function ($filter) use ($options, &$builder) {
+                    $builder = $this->filter($filter, $builder, $options);
                 });
             });
 

--- a/src/ReportBase.php
+++ b/src/ReportBase.php
@@ -486,6 +486,6 @@ abstract class ReportBase implements Responsable, Arrayable
     {
         $encodedData = $this->currentRequest->get('metaData', '');
 
-        return json_decode(base64_decode($encodedData));
+        return json_decode(json: base64_decode($encodedData), associative: true) ?? [];
     }
 }

--- a/src/ReportBase.php
+++ b/src/ReportBase.php
@@ -481,4 +481,10 @@ abstract class ReportBase implements Responsable, Arrayable
 
         return $output;
     }
+
+    public function getMetaData() : array
+    {
+        $encodedData = $this->currentRequest->get('metaData', '');
+        return json_decode(base64_decode($encodedData));
+    }
 }

--- a/src/ReportBase.php
+++ b/src/ReportBase.php
@@ -485,6 +485,7 @@ abstract class ReportBase implements Responsable, Arrayable
     public function getMetaData() : array
     {
         $encodedData = $this->currentRequest->get('metaData', '');
+
         return json_decode(base64_decode($encodedData));
     }
 }


### PR DESCRIPTION
This adds initial support for a metadata query param for report URLs that is an encoded json payload that currently supports a single timezone string value: `timezone`. The timezone value allows the report the have the context of the client's timezone when filtering datetime values. This works under the assumption that the datetime values that are being compared from the DB are in UTC