### PR TITLE
Data Types: Add support for dynamically setting the filter view template

### DIFF
--- a/src/BaseFeatures/Data/Types/Bases/BaseType.php
+++ b/src/BaseFeatures/Data/Types/Bases/BaseType.php
@@ -104,7 +104,7 @@ abstract class BaseType
     /**
      * @return string
      */
-    public function getFilterView()
+    public function getFilterView() : string
     {
         return $this->filterView;
     }

--- a/src/BaseFeatures/Data/Types/Bases/BaseType.php
+++ b/src/BaseFeatures/Data/Types/Bases/BaseType.php
@@ -22,6 +22,8 @@ abstract class BaseType
 
     protected ?string $formatter = null;
 
+    protected string $filterView = 'report-engine::partials.base-filter';
+
     /**
      * @param mixed       $value
      * @param object|null $result
@@ -99,6 +101,26 @@ abstract class BaseType
         return $this;
     }
 
+    /**
+     * @return string
+     */
+    public function getFilterView()
+    {
+        return $this->filterView;
+    }
+
+    /**
+     * @param string $filterView
+     *
+     * @return $this
+     */
+    public function setFilterView(string $filterView) : self
+    {
+        $this->filterView = $filterView;
+
+        return $this;
+    }
+
     public function getDefaultComparisonOperators() : array
     {
         return $this->default_comparison_operators;
@@ -162,7 +184,7 @@ abstract class BaseType
      */
     public function renderFilter(string $label, string $name, array $action_types, self $columnType, Collection $value)
     {
-        return view('report-engine::partials.base-filter')
+        return view($this->filterView)
             ->with(
                 $this->getConfig($label, $name, $action_types, $columnType, $value)
             );

--- a/src/BaseFeatures/Data/Types/DateTime.php
+++ b/src/BaseFeatures/Data/Types/DateTime.php
@@ -25,6 +25,8 @@ class DateTime extends BaseType
 
     protected ?string $formatter = 'datetime';
 
+    protected string $filterView = 'report-engine::partials.date-filter';
+
     public function __construct(
         string|null $outputFormat = null,
         string|null $placeholder = null,
@@ -139,7 +141,7 @@ class DateTime extends BaseType
             return Carbon::parse($value)->isoFormat($this->outputFormat);
         });
 
-        return view('report-engine::partials.date-filter')->with([
+        return view($this->filterView)->with([
             'label' => $label,
             'field' => $name,
             'value' => $value,

--- a/src/BaseFeatures/Data/Types/Enum.php
+++ b/src/BaseFeatures/Data/Types/Enum.php
@@ -12,6 +12,7 @@ class Enum extends BaseType
     protected $prepend_all = true;
     protected $default_value;
     protected $use_keys = false;
+    protected string $filterView = 'report-engine::partials.enum-filter';
 
     /**
      * Enum constructor.
@@ -117,7 +118,7 @@ class Enum extends BaseType
      */
     public function renderFilter(string $label, string $name, array $action_types, BaseType $columnType, Collection $value)
     {
-        return view('report-engine::partials.enum-filter')->with([
+        return view($this->filterView)->with([
             'label' => $label,
             'field' => $name,
             'options' => $this->options,

--- a/src/BaseFeatures/Data/Types/NullableDateTime.php
+++ b/src/BaseFeatures/Data/Types/NullableDateTime.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Collection;
 
 class NullableDateTime extends DateTime
 {
+    protected string $filterView = 'report-engine::partials.empty-not-empty-filter';
+
     public function __construct(?string $date_time_format = null, ?string $placeholder = null, ?string $output_tz_name = null)
     {
         parent::__construct($date_time_format, $placeholder, $output_tz_name);
@@ -27,7 +29,7 @@ class NullableDateTime extends DateTime
      */
     public function renderFilter(string $label, string $name, array $action_types, BaseType $columnType, Collection $value)
     {
-        return view('report-engine::partials.empty-not-empty-filter')->with([
+        return view($this->filterView)->with([
             'label' => $label,
             'field' => $name,
             'options' => collect($this->getOptions()),

--- a/src/BaseFeatures/Data/Types/YesNo.php
+++ b/src/BaseFeatures/Data/Types/YesNo.php
@@ -9,6 +9,8 @@ use Illuminate\Support\Collection;
 
 class YesNo extends BaseType
 {
+    protected string $filterView = 'report-engine::partials.yes-no-filter';
+
     /**
      * @param mixed       $value
      * @param object|null $result
@@ -44,7 +46,7 @@ class YesNo extends BaseType
      */
     public function renderFilter(string $label, string $name, array $action_types, BaseType $columnType, Collection $value)
     {
-        return view('report-engine::partials.yes-no-filter')->with([
+        return view($this->filterView)->with([
             'label' => $label,
             'field' => $name,
             'options' => collect($this->getOptions()),


### PR DESCRIPTION
## Description

This adds a minor change to allow setting the view for data type's filter when building them.

Any suggestions for other options to allow more control over the displaying of these filters?   I had thought about extending the data types themselves but that seemed like overkill for the pure presentation change I need